### PR TITLE
fix: 6월 22일 QA 수정사항 (방생성 일정등록, 시작페이지, 바텀시트)

### DIFF
--- a/src/components/bottomSheetShare/BottomSheetShare.tsx
+++ b/src/components/bottomSheetShare/BottomSheetShare.tsx
@@ -50,7 +50,7 @@ const BottomSheetShare = ({ roomUuid }: { roomUuid: string | undefined }) => {
       open={open}
       blocking={true}
       onDismiss={onDismiss}
-      snapPoints={({ minHeight }) => minHeight}
+      snapPoints={({ footerHeight }) => footerHeight}
     >
       <MainContainer>
         <HeaderRabbit src={headerRabbit} />

--- a/src/components/calendar/Calendar.styles.ts
+++ b/src/components/calendar/Calendar.styles.ts
@@ -61,9 +61,11 @@ export const CalendarComponent = styled(Calendar)`
     box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px;
   }
 
-  .rmdp-arrow-container:hover {
-    color: none;
-    background-color: none;
+  @media (min-width: 860px) {
+    .rmdp-arrow-container:hover {
+      color: none;
+      background-color: none;
+    }
   }
 
   @media (min-width: 860px) {
@@ -239,6 +241,16 @@ export const CalendarComponent = styled(Calendar)`
   }
 
   .rmdp-day.rmdp-day-hidden {
-    /* pointer-events: none; */
+    pointer-events: none;
+  }
+
+  .rmdp-arrow-container:hover {
+    background-color: white;
+    box-shadow: none;
+  }
+
+  .rmdp-arrow-container:hover .rmdp-arrow {
+    border: solid black !important;
+    border-width: 0 2px 2px 0 !important;
   }
 `;

--- a/src/components/calendar/Calendar.styles.ts
+++ b/src/components/calendar/Calendar.styles.ts
@@ -43,7 +43,7 @@ export const CalendarComponent = styled(Calendar)`
   .rmdp-day.rmdp-today.rmdp-range span {
     background-color: ${theme.colors.purple06};
     color: white;
-    box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px;
+    box-shadow: #dadef3 -0.4px 0px 0px 3px;
   }
 
   .rmdp-panel-body::-webkit-scrollbar-thumb {
@@ -66,9 +66,11 @@ export const CalendarComponent = styled(Calendar)`
     background-color: none;
   }
 
-  .rmdp-day:not(.rmdp-day-hidden) span:hover {
-    background-color: ${theme.colors.purple06};
-    box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px;
+  @media (min-width: 860px) {
+    .rmdp-day:not(.rmdp-day-hidden) span:hover {
+      background-color: ${theme.colors.purple06};
+      box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px;
+    }
   }
 
   .b-deselect {
@@ -84,9 +86,23 @@ export const CalendarComponent = styled(Calendar)`
     background-color: ${theme.colors.purple06};
   }
 
-  .rmdp-button:not(.rmdp-action-button):hover {
-    background-color: var(--rmdp-deselect-calendar);
-    box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px;
+  @media (min-width: 860px) {
+    .rmdp-button:not(.rmdp-action-button):hover {
+      background-color: var(--rmdp-deselect-calendar);
+      box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px;
+    }
+  }
+
+  @media (max-width: 860px) {
+    .rmdp-day:not(.rmdp-disabled):not(.rmdp-day-hidden) span:hover {
+      background-color: white;
+      color: black;
+    }
+  }
+
+  .rmdp-day.rmdp-selected span:not(.highlight) {
+    background-color: ${theme.colors.purple06} !important;
+    color: white !important;
   }
 
   .rmdp-header-values {
@@ -184,14 +200,14 @@ export const CalendarComponent = styled(Calendar)`
   }
 
   .rmdp-range.start span {
-    background-color: ${theme.colors.purple06};
-    color: white;
-    box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px;
+    background-color: ${theme.colors.purple06} !important;
+    color: white !important;
+    box-shadow: ${theme.colors.purple06} -0.4px 0px 0px 3px !important;
   }
 
   .rmdp-range.end span {
-    background: ${theme.colors.purple06};
-    color: white;
+    background: ${theme.colors.purple06} !important;
+    color: white !important;
     box-shadow: ${theme.colors.purple06} 0px 0px 0px 3px;
   }
 
@@ -205,6 +221,11 @@ export const CalendarComponent = styled(Calendar)`
     color: black;
   }
 
+  @media (max-width: 860px) {
+    .rmdp-range :hover {
+      background-color: #dadef3 !important;
+    }
+  }
   .rmdp-wrapper.rmdp-shadow.calendar {
     box-shadow: 0 0 0px white !important;
   }
@@ -215,5 +236,9 @@ export const CalendarComponent = styled(Calendar)`
 
   .rmdp-day.rmdp-disabled {
     pointer-events: none;
+  }
+
+  .rmdp-day.rmdp-day-hidden {
+    /* pointer-events: none; */
   }
 `;

--- a/src/components/calendar/Calendar.styles.ts
+++ b/src/components/calendar/Calendar.styles.ts
@@ -212,4 +212,8 @@ export const CalendarComponent = styled(Calendar)`
   .rmdp-top-class {
     width: 0px;
   }
+
+  .rmdp-day.rmdp-disabled {
+    pointer-events: none;
+  }
 `;

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -68,7 +68,6 @@ const Calendar = ({ dates, setDates }: Calendar) => {
       newDateArray.push(format);
     }
     setDates(newDateArray);
-    console.log('newDateArray', newDateArray);
   };
 
   useEffect(() => {
@@ -83,22 +82,21 @@ const Calendar = ({ dates, setDates }: Calendar) => {
         const allDates = getAllDatesInRange(Object(dataObjects), true);
         makeDatesRange(allDates);
       } else {
-        if (Object(dataObjects).length !== 0) {
-          for (const key in Object(dataObjects)) {
-            setValue(dataObjects);
-            const year = Object(dataObjects)[key].year;
-            const month = Object(dataObjects)[key].month;
-            const day = Object(dataObjects)[key].day;
-            const format =
-              year +
-              '-' +
-              ('00' + month.toString()).slice(-2) +
-              '-' +
-              ('00' + day.toString()).slice(-2);
-            const newArr = [...dates, format];
-            const newDateArr = Array.from(new Set(newArr));
-            setDates(newDateArr);
-          }
+        const newArr = [];
+        for (const key in Object(dataObjects)) {
+          setValue(dataObjects);
+          const year = Object(dataObjects)[key].year;
+          const month = Object(dataObjects)[key].month;
+          const day = Object(dataObjects)[key].day;
+          const format =
+            year +
+            '-' +
+            ('00' + month.toString()).slice(-2) +
+            '-' +
+            ('00' + day.toString()).slice(-2);
+          newArr.push(format);
+          const newDateArr = Array.from(new Set(newArr));
+          setDates(newDateArr);
         }
       }
     },

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { DateObject, getAllDatesInRange } from 'react-multi-date-picker';
 import {
   CalendarComponent,
@@ -14,6 +14,7 @@ interface Calendar {
 
 const Calendar = ({ dates, setDates }: Calendar) => {
   const [isRange, setIsRange] = useState<boolean>(true);
+  const [value, setValue] = useState();
 
   const ko = {
     name: 'ko',
@@ -70,6 +71,40 @@ const Calendar = ({ dates, setDates }: Calendar) => {
     console.log('newDateArray', newDateArray);
   };
 
+  useEffect(() => {
+    setDates([]);
+    setValue(undefined);
+  }, [isRange]);
+
+  const handleChangeDate = useCallback(
+    (dataObjects: any) => {
+      if (isRange) {
+        setValue(dataObjects);
+        const allDates = getAllDatesInRange(Object(dataObjects), true);
+        makeDatesRange(allDates);
+      } else {
+        if (Object(dataObjects).length !== 0) {
+          for (const key in Object(dataObjects)) {
+            setValue(dataObjects);
+            const year = Object(dataObjects)[key].year;
+            const month = Object(dataObjects)[key].month;
+            const day = Object(dataObjects)[key].day;
+            const format =
+              year +
+              '-' +
+              ('00' + month.toString()).slice(-2) +
+              '-' +
+              ('00' + day.toString()).slice(-2);
+            const newArr = [...dates, format];
+            const newDateArr = Array.from(new Set(newArr));
+            setDates(newDateArr);
+          }
+        }
+      }
+    },
+    [isRange, dates]
+  );
+
   return (
     <MainContainer>
       <ToggleWrapper>
@@ -80,28 +115,9 @@ const Calendar = ({ dates, setDates }: Calendar) => {
         />
       </ToggleWrapper>
       <CalendarComponent
+        value={value}
         onChange={(dataObjects) => {
-          if (isRange) {
-            const allDates = getAllDatesInRange(Object(dataObjects), true);
-            makeDatesRange(allDates);
-          } else {
-            if (Object(dataObjects).length !== 0) {
-              for (const key in Object(dataObjects)) {
-                const year = Object(dataObjects)[key].year;
-                const month = Object(dataObjects)[key].month;
-                const day = Object(dataObjects)[key].day;
-                const format =
-                  year +
-                  '-' +
-                  ('00' + month.toString()).slice(-2) +
-                  '-' +
-                  ('00' + day.toString()).slice(-2);
-                const newArr = [...dates, format];
-                const newDateArr = Array.from(new Set(newArr));
-                setDates(newDateArr);
-              }
-            }
-          }
+          handleChangeDate(dataObjects);
         }}
         locale={ko}
         multiple={true}

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -96,6 +96,9 @@ const Calendar = ({ dates, setDates }: Calendar) => {
             ('00' + day.toString()).slice(-2);
           newArr.push(format);
           const newDateArr = Array.from(new Set(newArr));
+          newDateArr.sort((a, b) => {
+            return new Date(a).getTime() - new Date(b).getTime();
+          });
           setDates(newDateArr);
         }
       }
@@ -125,6 +128,7 @@ const Calendar = ({ dates, setDates }: Calendar) => {
         minDate={new Date()}
         hideYear={true}
         buttons={true}
+        rangeHover={false}
       />
     </MainContainer>
   );

--- a/src/pages/start/start.styles.ts
+++ b/src/pages/start/start.styles.ts
@@ -11,6 +11,7 @@ export const MainContainer = styled.div`
   right: 0;
   margin: 0 auto;
   background-size: cover;
+  background-position: center;
   background-image: url(${startBack});
 `;
 


### PR DESCRIPTION
### 🔗 연관된 이슈 번호

#86 

### ✨ 어떤 기능을 개발했나요?

배포할 때 꼭 수정되어야 했던 문제사항들을 해결했고,
6월 22일에 진행한 QA의 수정사항은 다음과 같습니다.

[방 생성 일정등록]
- [x] 기간 선택 후 하나씩 선택으로 변경할 때 실제 데이터도 변경되지 않는 문제
- [x] 기간 선택 후 하나씩 선택으로 변경할 때 화면상으로 선택이 초기화되지 않는 문제
- [x] 기간 선택 후 취소했을 때 반영이 안되는 문제
- [x] 기간 선택하고 취소시 클릭이 밀리는 문제 (모바일)
- [x] 캘린더의 빈공간이 클릭되는 문제
- [x] 현재 날짜 이전 날짜가 클릭되는 문제 (모바일)
- [x] 월변경시 hover 속성이 유지되는 문제

[시작페이지]
- [x] 시작페이지 배경 중간정렬 맞지않는 문제 

[공유하기 바텀시트]
- [x] 공유하기 바텀시트 바텀이 바로 사라지지 않는 문제

### ✅ 어떻게 해결했나요?

대부분 CSS를 수정했고 모바일에서는 hover 속성에서 적용한 스타일이 그대로 유지되는 문제가 있더라고요.
@media (hover:none) 속성을 이용해서 모바일일때를 판단했고, hover 관련해서는 꾸준히 공부해야 될 것 같아요.

그리고 이전에는 날짜를 변경할 때 값을 초기화 하는 것이 아니라 계속해서 이전 값으로 부터 추가하는 방식으로 구현을 했었더라고요.
날짜를 선택하고 취소했을 때도 같은 로직이 적용이 되어서, 날짜 취소가 안되는 문제를 발견했고 이번 PR에서 해결했습니다.



### 📌 어떤 부분에 집중하여 리뷰해야 할까요?

### ❗️이 부분은 주의해 주세요! (Option)

### 🗂️ 참고자료 (Option)

### 🚀 결과 (Option)

---

### 💡 RCA 룰

- `r` 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- `c` 웬만하면 반영해 주세요.
- `a` 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- **규칙**
  - submit 할 코멘트들 중에서 1개라도 `r`이 포함되어 있다면 request change를 날립니다.
  - `r` 이 하나도 없다면 approve 합니다.
