### PR TITLE
fix: 약속시간 선택 페이지 TimePicker 기본값 변경

### DIFF
--- a/src/components/timePicker/TimePicker.tsx
+++ b/src/components/timePicker/TimePicker.tsx
@@ -14,7 +14,7 @@ interface Current {
 }
 
 const Current = ({ startTime, endTime, setStartTime, setEndTime }: Current) => {
-  const TIME_ARRAY = [
+  const START_TIME_ARRAY = [
     '09:00',
     '10:00',
     '11:00',
@@ -40,6 +40,32 @@ const Current = ({ startTime, endTime, setStartTime, setEndTime }: Current) => {
     '07:00',
     '08:00',
   ];
+  const END_TIME_ARRAY = [
+    '18:00',
+    '19:00',
+    '20:00',
+    '21:00',
+    '22:00',
+    '23:00',
+    '00:00',
+    '01:00',
+    '02:00',
+    '03:00',
+    '04:00',
+    '05:00',
+    '06:00',
+    '07:00',
+    '08:00',
+    '09:00',
+    '10:00',
+    '11:00',
+    '12:00',
+    '13:00',
+    '14:00',
+    '15:00',
+    '16:00',
+    '17:00',
+  ];
 
   const settings = (startEnd: string) => {
     const setting = {
@@ -51,9 +77,9 @@ const Current = ({ startTime, endTime, setStartTime, setEndTime }: Current) => {
       swipeToSlide: true,
       afterChange: function (currentSlide: number) {
         if (startEnd === 'start') {
-          setStartTime(TIME_ARRAY[currentSlide]);
+          setStartTime(START_TIME_ARRAY[currentSlide]);
         } else {
-          setEndTime(TIME_ARRAY[currentSlide]);
+          setEndTime(END_TIME_ARRAY[currentSlide]);
         }
       },
       centerMode: true,
@@ -74,7 +100,7 @@ const Current = ({ startTime, endTime, setStartTime, setEndTime }: Current) => {
   return (
     <MainContainer>
       <StyledSlider {...settings('start')}>
-        {TIME_ARRAY.map((time: string) => {
+        {START_TIME_ARRAY.map((time: string) => {
           return (
             <div key={time}>
               <TimeText>{time}</TimeText>
@@ -84,7 +110,7 @@ const Current = ({ startTime, endTime, setStartTime, setEndTime }: Current) => {
       </StyledSlider>
       <TextContainer>부터</TextContainer>
       <StyledSlider {...settings('end')}>
-        {TIME_ARRAY.map((time: string) => {
+        {END_TIME_ARRAY.map((time: string) => {
           return (
             <div key={time}>
               <TimeText>{time}</TimeText>

--- a/src/pages/roomCalendar/RoomCalendar.tsx
+++ b/src/pages/roomCalendar/RoomCalendar.tsx
@@ -24,18 +24,10 @@ import dayjs from 'dayjs';
 const RoomCalendar = () => {
   const [isCheckedBox, setIsCheckedBox] = useState(false);
   const [startTime, setStartTime] = useState('09:00');
-  const [endTime, setEndTime] = useState('09:00');
+  const [endTime, setEndTime] = useState('18:00');
   const [dates, setDates] = useState<string[]>([]);
 
   const [recoilRoom, setRecoilRoom] = useRecoilState(recoilRoomAtoms);
-
-  const newStartTime = dayjs(`1900-01-01 ${startTime}`);
-  const newEndTime = dayjs(`1900-01-01 ${endTime}`);
-
-  const canGoNext =
-    isCheckedBox ||
-    (dayjs(newStartTime).format() != dayjs(newEndTime).format() &&
-      dates.length !== 0);
 
   const onSetRecoilState = useCallback(() => {
     if (isCheckedBox) {
@@ -85,15 +77,11 @@ const RoomCalendar = () => {
           setValue={setIsCheckedBox}
         />
       </CheckBoxContainer>
-      {canGoNext ? (
-        <Link to="/roomTimer">
-          <BottomButtonContainer onClick={onSetRecoilState}>
-            <BottomButton text="다음" isActivated={canGoNext} />
-          </BottomButtonContainer>
-        </Link>
-      ) : (
-        <BottomButton text="다음" isActivated={canGoNext} />
-      )}
+      <Link to="/roomTimer">
+        <BottomButtonContainer onClick={onSetRecoilState}>
+          <BottomButton text="다음" isActivated={true} />
+        </BottomButtonContainer>
+      </Link>
     </MainContainer>
   );
 };


### PR DESCRIPTION
### 🔗 연관된 이슈 번호
#109 

### ✨ 어떤 기능을 개발했나요?

- [x] 약속종료 시간 09:00 -> 18:00 변경
- [x] 약속시간 선택안해도 기본 값으로 09:00 ~ 18:00가 선택되고, 다음 버튼 활성화

### ✅ 어떻게 해결했나요?

시작시간과 끝 시간 배열을 분리하여, 끝 시간은 18:00부터 시작되도록 구현했습니다.
기존 canGoNext 변수로 다음 버튼 활성화 여부를 관리하였는데, 선택을 하지않아도 default 값으로 09:00 ~ 18:00 값을 전달합니다.

### 📌 어떤 부분에 집중하여 리뷰해야 할까요?

### ❗️이 부분은 주의해 주세요! (Option)

### 🗂️ 참고자료 (Option)

### 🚀 결과 (Option)
<img width="800" alt="image" src="https://github.com/dnd-side-project/dnd-8th-5-frontend/assets/81014501/f5a096d8-7918-4bfd-8f46-386a997fae98">


---

### 💡 RCA 룰

- `r` 꼭 반영해 주세요. 적극적으로 고려해 주세요.
- `c` 웬만하면 반영해 주세요.
- `a` 반영해도 좋고 안 해도 좋습니다. 사소한 의견입니다.
- **규칙**
  - submit 할 코멘트들 중에서 1개라도 `r`이 포함되어 있다면 request change를 날립니다.
  - `r` 이 하나도 없다면 approve 합니다.
