### PR TITLE
fix: 방 생성 중복 요청 해결

### DIFF
--- a/src/pages/roomTimer/index.tsx
+++ b/src/pages/roomTimer/index.tsx
@@ -49,7 +49,7 @@ const RoomTimer = () => {
 
   const { mutate, data, isError, isSuccess } = useCreateRoom();
 
-  useEffect(() => {
+  const handleCreateRoom = useCallback(() => {
     if (
       day ||
       minute ||
@@ -58,18 +58,20 @@ const RoomTimer = () => {
       isChecked
     ) {
       mutate(room);
-
-      if (isError) {
-        confirm('오류가 발생했습니다.\n처음부터 다시 시도해 주세요.');
-        navigate(`${ROUTES.LANDING}`);
-      }
-
-      if (isSuccess) {
-        navigate(`${ROUTES.CURRENT}/${data.roomUuid}`);
-        setIsLinkShareBottomSheetOpened(true);
-      }
     }
-  }, [room, isError, isSuccess]);
+  }, [day, minute, hour, isClickedRecommend, isChecked, mutate, room]);
+
+  useEffect(() => {
+    if (isError) {
+      confirm('오류가 발생했습니다.\n처음부터 다시 시도해 주세요.');
+      navigate(`${ROUTES.LANDING}`);
+    }
+
+    if (isSuccess && data) {
+      navigate(`${ROUTES.CURRENT}/${data.roomUuid}`);
+      setIsLinkShareBottomSheetOpened(true);
+    }
+  }, [isError, isSuccess, data]);
 
   useEffect(() => {
     setIsClickedRecommend((prev) =>
@@ -123,39 +125,24 @@ const RoomTimer = () => {
       recommendMinute = 0;
     }
 
-    setRoom((prev: any) => {
+    setRoom((prev) => {
       return {
         ...prev,
-        timer: isChecked
-          ? null
-          : {
-              day: isChecked
-                ? null
-                : isClickedRecommend.indexOf(true) >= 0
-                ? recommendDay
-                : day,
-              hour: isChecked
-                ? null
-                : isClickedRecommend.indexOf(true) >= 0
-                ? recommendHour
-                : hour,
-              minute: isChecked
-                ? null
-                : isClickedRecommend.indexOf(true) >= 0
-                ? recommendMinute
-                : minute,
-            },
+        ['timeLimit']: isChecked
+          ? 0
+          : recommendDay * 24 * 60 + recommendHour * 60 + recommendMinute,
       };
     });
+
+    handleCreateRoom();
   }, [
     day,
     hour,
     minute,
-    isChecked,
-    room,
     isClickedRecommend,
-    room,
-    recoilRoomInfoStates,
+    isChecked,
+    setRoom,
+    handleCreateRoom,
   ]);
 
   return (


### PR DESCRIPTION
### 🔗 연관된 이슈 번호 
#134 

### ✨ 어떤 기능을 개발했나요?

아래 문제를 해결하였습니다.
1. mutate(room) 호출
2. mutate 호출로 인해 isSuccess가 변경됨
3. isSuccess 변경으로 인해 useEffect가 다시 실행됨
4. 다시 mutate(room) 호출

### ✅ 어떻게 해결했나요?

1. API 호출 로직을 handleCreateRoom이라는 별도의 함수로 분리했습니다.
5. useEffect를 두 개로 분리하여 API 호출과 상태 처리를 분리했습니다:
   - 첫 번째 useEffect는 API 호출 결과(isError, isSuccess)에 따른 처리만 담당
   - handleCreateRoom 함수는 실제 API 호출만 담당
6. handleClickCompleteButton 함수에서 상태 업데이트 후 handleCreateRoom을 호출하도록 변경했습니다.

### 📌 어떤 부분에 집중하여 리뷰해야 할까요?
- 다른 부분에 영향이 가는지 확인해주세요.

### ❗️이 부분은 주의해 주세요! (Option)

### 🗂️ 참고자료 (Option)

### 🚀 결과 (Option)

<br/>
