### PR TITLE
fix: activeStartDate를 defaultActiveStartDate으로 변경

### DIFF
--- a/src/pages/addTime/index.tsx
+++ b/src/pages/addTime/index.tsx
@@ -68,7 +68,7 @@ const AddTime = () => {
             />
           ) : (
             <AddCalendar
-              activeStartDate={
+              defaultActiveStartDate={
                 room?.dates?.[0] ? new Date(room.dates[0]) : new Date()
               }
               dates={room.dates}

--- a/src/pages/current/index.tsx
+++ b/src/pages/current/index.tsx
@@ -139,7 +139,7 @@ const Current = () => {
           </TableWrapper>
         ) : (
           <CurrentCalendar
-            activeStartDate={
+            defaultActiveStartDate={
               data.dates?.[0] ? new Date(data.dates[0]) : new Date()
             }
             participants={participants}

--- a/src/pages/roomCalendar/index.tsx
+++ b/src/pages/roomCalendar/index.tsx
@@ -53,7 +53,7 @@ const RoomCalendar = () => {
   };
 
   useEffect(() => {
-    if (dates.length !== 0 && startTime !== endTime) {
+    if ((isCheckedBox || startTime !== endTime) && dates.length > 0) {
       setIsActivated(true);
     } else {
       setIsActivated(false);


### PR DESCRIPTION
### 🔗 연관된 이슈 번호
resolve #140 

### ✨ 어떤 기능을 개발했나요?
- 캘린더 월별 이동이 안 되는 문제 해결

### ✅ 어떻게 해결했나요?
- activeStartDate를 defaultActiveStartDate으로 변경

### 📌 어떤 부분에 집중하여 리뷰해야 할까요?
- X

### ❗️이 부분은 주의해 주세요! (Option)

### 🗂️ 참고자료 (Option)

### 🚀 결과 (Option)

<br/>
